### PR TITLE
ci: add central workflows including release-please

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,0 +1,9 @@
+---
+name: "Linters"
+
+on:
+  pull_request:
+
+jobs:
+  linters:
+    uses: camptocamp/devops-stack/.github/workflows/modules-linters.yaml@master

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,0 +1,11 @@
+---
+name: "Release"
+
+on:
+  push:
+    branches:
+    - "main"
+
+jobs:
+  release:
+    uses: camptocamp/devops-stack/.github/workflows/modules-release-please.yaml@master

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -7,5 +7,3 @@ on:
 jobs:
   terraform-docs:
     uses: camptocamp/devops-stack/.github/workflows/modules-terraform-docs.yaml@master
-    with:
-      variants: "eks"

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -1,0 +1,11 @@
+---
+name: "Terraform Docs"
+
+on:
+  pull_request:
+
+jobs:
+  terraform-docs:
+    uses: camptocamp/devops-stack/.github/workflows/modules-terraform-docs.yaml@master
+    with:
+      variants: "eks"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @camptocamp/is-devops-stack

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,305 @@
+// BEGIN_TF_DOCS
+=== Requirements
+
+No requirements.
+
+=== Providers
+
+The following providers are used by this module:
+
+- [[provider_argocd]] <<provider_argocd,argocd>>
+
+- [[provider_null]] <<provider_null,null>>
+
+- [[provider_utils]] <<provider_utils,utils>>
+
+=== Modules
+
+No modules.
+
+=== Resources
+
+The following resources are used by this module:
+
+- https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/application[argocd_application.this] (resource)
+- https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/project[argocd_project.this] (resource)
+- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] (resource)
+- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] (resource)
+- https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml[utils_deep_merge_yaml.helm_values] (data source)
+
+=== Required Inputs
+
+The following input variables are required:
+
+==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
+
+Description: n/a
+
+Type: `string`
+
+==== [[input_base_domain]] <<input_base_domain,base_domain>>
+
+Description: n/a
+
+Type: `string`
+
+==== [[input_clients]] <<input_clients,clients>>
+
+Description: n/a
+
+Type:
+[source,hcl]
+----
+map(object({
+    id     = string
+    name   = string
+    secret = string
+
+    public = bool
+
+    redirect_uris = list(string)
+  }))
+----
+
+==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
+
+Description: n/a
+
+Type: `string`
+
+==== [[input_cluster_name]] <<input_cluster_name,cluster_name>>
+
+Description: n/a
+
+Type: `string`
+
+==== [[input_connectors]] <<input_connectors,connectors>>
+
+Description: n/a
+
+Type: `any`
+
+=== Optional Inputs
+
+The following input variables are optional (have default values):
+
+==== [[input_custom_image]] <<input_custom_image,custom_image>>
+
+Description: n/a
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_dependency_ids]] <<input_dependency_ids,dependency_ids>>
+
+Description: n/a
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_namespace]] <<input_destination_namespace,destination_namespace>>
+
+Description: n/a
+
+Type: `string`
+
+Default: `"dex"`
+
+==== [[input_helm_values]] <<input_helm_values,helm_values>>
+
+Description: n/a
+
+Type: `any`
+
+Default: `[]`
+
+==== [[input_name]] <<input_name,name>>
+
+Description: n/a
+
+Type: `string`
+
+Default: `"dex"`
+
+==== [[input_source_repository_url]] <<input_source_repository_url,source_repository_url>>
+
+Description: n/a
+
+Type: `string`
+
+Default: `"https://github.com/camptocamp/devops-stack-module-dex.git"`
+
+==== [[input_source_target_revision]] <<input_source_target_revision,source_target_revision>>
+
+Description: n/a
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_target_revision]] <<input_target_revision,target_revision>>
+
+Description: Override for target revision of the application chart.
+
+Type: `string`
+
+Default: `"v1.0.0-alpha.1"`
+
+=== Outputs
+
+The following outputs are exported:
+
+==== [[output_clients]] <<output_clients,clients>>
+
+Description: n/a
+
+==== [[output_id]] <<output_id,id>>
+
+Description: n/a
+
+==== [[output_issuer_url]] <<output_issuer_url,issuer_url>>
+
+Description: n/a
+// END_TF_DOCS
+// BEGIN_TF_TABLES
+
+
+= Providers
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[provider_argocd]] <<provider_argocd,argocd>> |n/a
+|[[provider_null]] <<provider_null,null>> |n/a
+|[[provider_utils]] <<provider_utils,utils>> |n/a
+|===
+
+= Resources
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Type
+|https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/application[argocd_application.this] |resource
+|https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/project[argocd_project.this] |resource
+|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] |resource
+|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] |resource
+|https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml[utils_deep_merge_yaml.helm_values] |data source
+|===
+
+= Inputs
+
+[cols="a,a,a,a,a",options="header,autowidth"]
+|===
+|Name |Description |Type |Default |Required
+|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
+|n/a
+|`string`
+|n/a
+|yes
+
+|[[input_base_domain]] <<input_base_domain,base_domain>>
+|n/a
+|`string`
+|n/a
+|yes
+
+|[[input_clients]] <<input_clients,clients>>
+|n/a
+|
+
+[source]
+----
+map(object({
+    id     = string
+    name   = string
+    secret = string
+
+    public = bool
+
+    redirect_uris = list(string)
+  }))
+----
+
+|n/a
+|yes
+
+|[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
+|n/a
+|`string`
+|n/a
+|yes
+
+|[[input_cluster_name]] <<input_cluster_name,cluster_name>>
+|n/a
+|`string`
+|n/a
+|yes
+
+|[[input_connectors]] <<input_connectors,connectors>>
+|n/a
+|`any`
+|n/a
+|yes
+
+|[[input_custom_image]] <<input_custom_image,custom_image>>
+|n/a
+|`string`
+|`null`
+|no
+
+|[[input_dependency_ids]] <<input_dependency_ids,dependency_ids>>
+|n/a
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_namespace]] <<input_destination_namespace,destination_namespace>>
+|n/a
+|`string`
+|`"dex"`
+|no
+
+|[[input_helm_values]] <<input_helm_values,helm_values>>
+|n/a
+|`any`
+|`[]`
+|no
+
+|[[input_name]] <<input_name,name>>
+|n/a
+|`string`
+|`"dex"`
+|no
+
+|[[input_source_repository_url]] <<input_source_repository_url,source_repository_url>>
+|n/a
+|`string`
+|`"https://github.com/camptocamp/devops-stack-module-dex.git"`
+|no
+
+|[[input_source_target_revision]] <<input_source_target_revision,source_target_revision>>
+|n/a
+|`string`
+|`null`
+|no
+
+|[[input_target_revision]] <<input_target_revision,target_revision>>
+|Override for target revision of the application chart.
+|`string`
+|`"v1.0.0-alpha.1"`
+|no
+
+|===
+
+= Outputs
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Description
+|[[output_clients]] <<output_clients,clients>> |n/a
+|[[output_id]] <<output_id,id>> |n/a
+|[[output_issuer_url]] <<output_issuer_url,issuer_url>> |n/a
+|===
+// END_TF_TABLES

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ resource "argocd_application" "this" {
     source {
       repo_url        = var.source_repository_url
       path            = "helm"
-      target_revision = coalesce(var.target_revision, trimspace(file("${path.module}/version.txt")))
+      target_revision = var.target_revision
 
       helm {
         values = data.utils_deep_merge_yaml.helm_values.output

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ resource "argocd_application" "this" {
     source {
       repo_url        = var.source_repository_url
       path            = "helm"
-      target_revision = coalesce(var.source_target_revision, trimspace(file("${path.module}/version.txt")))
+      target_revision = coalesce(var.target_revision, trimspace(file("${path.module}/version.txt")))
 
       helm {
         values = data.utils_deep_merge_yaml.helm_values.output

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "argocd_namespace" {
 variable "target_revision" {
   description = "Override for target revision of the application chart."
   type        = string
-  default     = null
+  default     = "v1.0.0-alpha.1" # x-release-please-version
 }
 
 variable "base_domain" {

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,12 @@ variable "argocd_namespace" {
   type = string
 }
 
+variable "target_revision" {
+  description = "Override for target revision of the application chart."
+  type        = string
+  default     = null
+}
+
 variable "base_domain" {
   type = string
 }

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-main
+v1.0.0-alpha.1


### PR DESCRIPTION
Apart from adding the CI workflows to generate the docs and lint the code, this PR also adds the Release Please workflow and associated modifications.

I also added the CODEOWNERS and LICENSE files in this PR to avoid creating a new one only for that.

**IMPORTANT**: Before merging with main, do not forget to add the comment `Release-As: v1.0.0-alpha.1` if you want to release as this prerelease.