### PR TITLE
feat!: add support to oboukili/argocd v5

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,15 +1,19 @@
 // BEGIN_TF_DOCS
+=== Requirements
 
+The following requirements are needed by this module:
+
+- [[requirement_argocd]] <<requirement_argocd,argocd>> (>= 5)
 
 === Providers
 
 The following providers are used by this module:
 
-- [[provider_utils]] <<provider_utils,utils>>
-
-- [[provider_argocd]] <<provider_argocd,argocd>>
-
 - [[provider_null]] <<provider_null,null>>
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_utils]] <<provider_utils,utils>>
 
 === Resources
 
@@ -182,7 +186,13 @@ Description: n/a
 Description: n/a
 // END_TF_DOCS
 // BEGIN_TF_TABLES
+= Requirements
 
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[requirement_argocd]] <<requirement_argocd,argocd>> |>= 5
+|===
 
 = Providers
 
@@ -190,7 +200,7 @@ Description: n/a
 |===
 |Name |Version
 |[[provider_utils]] <<provider_utils,utils>> |n/a
-|[[provider_argocd]] <<provider_argocd,argocd>> |n/a
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_null]] <<provider_null,null>> |n/a
 |===
 

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,20 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated = var.app_autosync 
+      automated {
+        prune       = var.app_autosync.prune
+        self_heal   = var.app_autosync.self_heal
+        allow_empty = var.app_autosync.allow_empty
+      }
+
+      retry {
+        backoff {
+          duration     = "20s"
+          max_duration = "2m"
+          factor       = "2"
+        }
+        limit = "5"
+      }
 
       sync_options = [
         "CreateNamespace=true"

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     argocd = {
-      source = "oboukili/argocd"
+      source  = "oboukili/argocd"
+      version = ">= 5"
     }
 
     utils = {


### PR DESCRIPTION
## Description of the changes

Adapt the module to be compatible with ArgoCD versions >= 5.x (in counterpart, it now incompatible with previous versions of the provider). 
This change to the provider is needed to work with ArgoCD 2.7.x

## Breaking change

- [ ] No
- [ ] Yes (in the Helm chart(s))
- [x] Yes (in the module itself): _the module is no longer compatible with argocd provider versions < 5.x_

## Tests executed on which distribution(s)

- [ ] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [x] SKS (Exoscale)