### PR TITLE
fix: readd support to deactivate auto-sync which was broken by #11

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,11 +9,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>>
-
 - [[provider_utils]] <<provider_utils,utils>>
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_null]] <<provider_null,null>>
 
 === Resources
 

--- a/main.tf
+++ b/main.tf
@@ -63,10 +63,13 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated {
-        prune       = var.app_autosync.prune
-        self_heal   = var.app_autosync.self_heal
-        allow_empty = var.app_autosync.allow_empty
+      dynamic "automated" {
+        for_each = toset(var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? [] : [var.app_autosync])
+        content {
+          prune       = automated.value.prune
+          self_heal   = automated.value.self_heal
+          allow_empty = automated.value.allow_empty
+        }
       }
 
       retry {


### PR DESCRIPTION
## Description of the changes

This PR:
- re-adds the support to deactivate the auto-sync, which was broken by the use of dynamic Terraform blocks on the PR #11. This is not a breaking change, because users can still use the old way of passing an empty map to the `app_autosync` variable in order do deactivate the auto-sync.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

I have not had the chance to test this module, but the changes should not pose any issue since they are really similar to other modules.